### PR TITLE
Agrega configuración base de datos dockerizada

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+db-iniciar:
+	cd ./tools && docker-compose up -d
+
+db-iniciar-logs:
+	cd ./tools && docker-compose up
+
+db-frenar:
+	cd ./tools && docker-compose stop
+
+db-borrar:
+	cd ./tools && docker-compose down -v
+

--- a/README.md
+++ b/README.md
@@ -4,3 +4,50 @@
 
 - Local: http://localhost:8090/swagger-ui.html
 - Heorku: https://modulo-proyectos-squad7.herokuapp.com/swagger-ui.html
+
+## Base de datos
+
+La base de datos está implementada con [PostgreSQL](https://es.wikipedia.org/wiki/PostgreSQL). La base de datos está dockerizada, por lo que solo con tener instalado [Docker](https://docs.docker.com/engine/install/ubuntu/) y [Docker Compose](https://docs.docker.com/compose/install/) es suficiente.
+Todos los archivos de configuración ligados a Docker están en [tools](tools).
+
+Los datos de conexión a la base de datos localmente son:
+```bash
+host: 127.0.0.1
+puerto: 5434
+usuario: username
+constraseña: password
+database: proyectos_db
+```
+
+Para interactuar facilmente con la base de datos tenemos tenemos los siguientes comandos:
+
+**Iniciar la Base de Datos**
+
+Si no está levantada, la app no se podrá conectar a la DB.
+
+Iniciar la base:
+
+```bash
+$ make db-iniciar
+```
+
+Para iniciar la base de datos mostrando logs en pantalla:
+```bash
+$ make db-iniciar-logs
+```
+
+**Apagar la Base de Datos**
+
+```bash
+$ make db-frenar
+```
+
+**Borrar la Base de Datos**
+
+Si se corre este comando será irreversible la perdida de toda la información que hubiera en la base
+
+```bash
+$ make db-borrar
+```
+
+**NOTA:** No es mandatorio usar Docker para gestionar la base de datos, se puede usar PostgreSQL directamente instalado en el sistema (je, cuidado con problemas del tipo *En mi máquina funciona bien*)

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ dependencies {
 	compile group: 'com.h2database', name: 'h2', version: '1.4.200'
 	//compile group: 'mysql', name: 'mysql-connector-java', version: '8.0.19'
 
+	compile group: 'org.postgresql', name: 'postgresql', version: '9.4-1200-jdbc41'
+
 	testImplementation("info.cukes:cucumber-java:1.2.5")
 	testImplementation("info.cukes:cucumber-junit:1.2.5")
 	testImplementation("info.cukes:cucumber-spring:1.2.5")
@@ -33,6 +35,7 @@ dependencies {
 	testRuntime("org.junit.jupiter:junit-jupiter-engine:5.3.1")
 
 }
+
 tasks.withType(Test){
 	scanForTestClasses = false
 	include "**/*Test.class"

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,11 +1,22 @@
-spring.datasource.url=jdbc:h2:mem:DBNAME
-spring.datasource.username=root
-spring.datasource.password=SA
-spring.datasource.driverClassName=org.h2.Driver
-spring.h2.console.enabled=true
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-spring.datasource.initialize=true
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
-spring.jpa.hibernate.ddl-auto=create
-server.port = 8090
+# Data Base Config
+
+spring.jpa.database=POSTGRESQL
+spring.jpa.hibernate.ddl-auto=update
+
+# The SQL dialect makes Hibernate generate better SQL for the chosen database
+
+spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
+
+
+# Data Base crendentials
+
+spring.datasource.url=jdbc:postgresql://${DB_HOST:127.0.0.1}:${DB_PORT:5434}/${DB_NAME:proyectos_db}
+spring.datasource.username=${DB_USER:username}
+spring.datasource.password=${DB_PASS:password}
+
+# Debug
+
+# Show sql in console:
+spring.jpa.show-sql=false

--- a/tools/db_init.sql
+++ b/tools/db_init.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE proyectos_db;

--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.6'
+services:
+  postgres:
+    image: postgres:11.9
+    container_name: squad7-proyectos
+    restart: always
+    environment:
+      - DATABASE_HOST=127.0.0.1
+      - POSTGRES_USER=username
+      - POSTGRES_PASSWORD=password
+    ports:
+      - '5434:5432'
+    volumes:
+      - ./db_init.sql:/docker-entrypoint-initdb.d/db_init.sql


### PR DESCRIPTION
El Mr agrega herramientas para levantar la base de datos postgresql con docker, ya están configuradas las properties para conectarse a dicha base en el proyecto, y configuradas las variables de entorno para poder conectar una base de datos en Heroku. 

Lo que si falta es agregar la dependencia de `jdbc` en gradle, eso es algo por hacer.

Les dejo el Readme sobre cómo utilizar la base de datos (agregue un make para que sea mas fácil interactuar con docker si es que estan en linux o mac. En windows no sirven los comandos `make`):

## Base de datos

La base de datos está implementada con [PostgreSQL](https://es.wikipedia.org/wiki/PostgreSQL). La base de datos está dockerizada, por lo que solo con tener instalado [Docker](https://docs.docker.com/engine/install/ubuntu/) y [Docker Compose](https://docs.docker.com/compose/install/) es suficiente.
Todos los archivos de configuración ligados a Docker están en [tools](tools). 

Los datos de conexión a la base de datos localmente son: 
```bash
host: 127.0.0.1
usuario: username
constraseña: password
database: proyectos_db
port: 5434
```

Para interactuar facilmente con la base de datos tenemos tenemos los siguientes comandos:

**Iniciar la Base de Datos**

Si no está levantada, la app no se podrá conectar a la DB.

Iniciar la base:

```bash
$ make db-iniciar
```

Para iniciar la base de datos mostrando logs en pantalla:
```bash
$ make db-iniciar-logs
```

**Apagar la Base de Datos**

```bash
$ make db-frenar
```

**Borrar la Base de Datos**

Si se corre este comando será irreversible la perdida de toda la información que hubiera en la base

```bash
$ make db-borrar
```

**NOTA:** No es mandatorio usar Docker para gestionar la base de datos, se puede usar PostgreSQL directamente instalado en el sistema (je, cuidado con problemas del tipo *En mi máquina funciona bien*)
